### PR TITLE
add support to print objects via cling commadline

### DIFF
--- a/Etaler/Core/Shape.hpp
+++ b/Etaler/Core/Shape.hpp
@@ -165,3 +165,14 @@ inline Shape foldIndex(size_t index, const ShapeType& shape)
 }
 
 }
+
+//Print Shape at the prompt
+namespace cling
+{
+
+inline std::string printValue(const et::Shape* value)
+{
+	return et::to_string(*value);
+}
+
+}

--- a/Etaler/Core/Tensor.hpp
+++ b/Etaler/Core/Tensor.hpp
@@ -309,3 +309,19 @@ static Tensor logical_and(const Tensor& x1, const Tensor& x2) { return x1.logica
 static Tensor logical_or(const Tensor& x1, const Tensor& x2) { return x1.logical_or(x2); }
 
 }
+
+#include <sstream>
+
+namespace cling
+{
+
+//FIXME: For some weard reson, I can't just return et::to_string(*value) and this function have to be inlined.
+//Otherwise cling crashes.
+inline std::string printValue(const et::Tensor* value)
+{
+	std::stringstream ss;
+	ss << *value;
+	return ss.str();
+}
+
+}


### PR DESCRIPTION
Implements #35 
Now Tensor and Shape will print useful information in cling/ROOT's prompt. 

Ex:
```C++
root [0] #pragma cling load("/usr/local/lib/libEtaler.so")
root [1] #include <Etaler/Etaler.hpp>
root [2] using namespace et;
root [3] t = ones({4,4})
(et::Tensor &) {{ 1, 1, 1, 1}, 
 { 1, 1, 1, 1}, 
 { 1, 1, 1, 1}, 
 { 1, 1, 1, 1}}
root [4] t.shape()
(et::Shape) {4, 4}
root [5]
```