### PR TITLE
Add FP16 capablity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Etaler/3rdparty/pcg-cpp"]
 	path = Etaler/3rdparty/pcg-cpp
 	url = https://github.com/imneme/pcg-cpp
+[submodule "Etaler/3rdparty/half_precision"]
+	path = Etaler/3rdparty/half_precision
+	url = https://github.com/marty1885/half_precision

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
+project(Etaler)
+
 
 SET(BUILD_SHARED_LIBS ON)
 

--- a/Etaler/Algorithms/SpatialPooler.hpp
+++ b/Etaler/Algorithms/SpatialPooler.hpp
@@ -71,7 +71,7 @@ struct ETALER_EXPORT SpatialPooler
 	{
 		return to(connections_.backend());
 	}
-protected:
+//protected:
 	float permanence_inc_ = 0.1;
 	float permanence_dec_ = 0.1;
 	float connected_permanence_ = 0.21;

--- a/Etaler/Backends/CPUBackend.cpp
+++ b/Etaler/Backends/CPUBackend.cpp
@@ -572,6 +572,8 @@ std::shared_ptr<TensorImpl> CPUBackend::sum(const TensorImpl* x, size_t chunk_si
 			DType dtype = x->dtype();
 			if(dtype == DType::Bool || dtype == DType::Int32)
 				return DType::Int32;
+			else if(dtype == DType::Half)
+				return DType::Half;
 			else
 				return DType::Float;
 		}();

--- a/Etaler/Backends/CPUBackend.cpp
+++ b/Etaler/Backends/CPUBackend.cpp
@@ -449,8 +449,10 @@ void dispatch(DType dtype, Func f)
 		f(float{});
 	else if(dtype == DType::Bool)
 		f(bool{});
+	else if(dtype == DType::Half)
+		f(half{});
 	else
-		throw EtError("Cannot realize such dtype");
+		throw EtError("Cannot dispatch such dtype");
 }
 
 template <typename T2, typename T1>

--- a/Etaler/Backends/CPUBackend.cpp
+++ b/Etaler/Backends/CPUBackend.cpp
@@ -473,7 +473,8 @@ static std::shared_ptr<TensorImpl> uniaryOp(const TensorImpl* src, Op op)
 			auto res = op(*ptr);
 			using ResType = decltype(res);
 			//We don't have support to double percition now. Cast it to float
-			using StoreType = typename std::conditional<std::is_same<ResType, double>::value, float, ResType>::type;
+			using StoreType = typename std::conditional_t<std::is_same_v<T, half>, half
+				, typename std::conditional_t<std::is_same_v<ResType, double>, float, ResType>>;
 			if(i == 0)
 				dest = src->backend()->createTensor(src->shape(), typeToDType<StoreType>());
 

--- a/Etaler/Backends/CPUBackend.cpp
+++ b/Etaler/Backends/CPUBackend.cpp
@@ -473,8 +473,9 @@ static std::shared_ptr<TensorImpl> uniaryOp(const TensorImpl* src, Op op)
 			auto res = op(*ptr);
 			using ResType = decltype(res);
 			//We don't have support to double percition now. Cast it to float
-			using StoreType = typename std::conditional_t<std::is_same_v<T, half>, half
-				, typename std::conditional_t<std::is_same_v<ResType, double>, float, ResType>>;
+			using StoreType = typename std::conditional_t<std::is_same_v<ResType, bool>, bool
+				, typename std::conditional_t<std::is_same_v<T, half>, half
+				, typename std::conditional_t<std::is_same_v<ResType, double>, float, ResType>>>;
 			if(i == 0)
 				dest = src->backend()->createTensor(src->shape(), typeToDType<StoreType>());
 

--- a/Etaler/Backends/CPUBackend.hpp
+++ b/Etaler/Backends/CPUBackend.hpp
@@ -23,6 +23,8 @@ struct CPUBuffer : public BufferImpl
 			storage_ = new int32_t[shape.volume()];
 		else if(dtype == DType::Float)
 			storage_ = new float[shape.volume()];
+		else if(dtype == DType::Half)
+			storage_ = new half[shape.volume()];
 		else
 			std::cerr << "Critical Warning: CPUBuffer Initialize failed. Unknown DType" << std::endl;
 	}
@@ -42,7 +44,7 @@ struct CPUBuffer : public BufferImpl
 	virtual void* data() const override;
 
 protected:
-	std::variant<bool*, int32_t*, float*> storage_;
+	std::variant<bool*, int32_t*, float*, half*> storage_;
 };
 
 struct CPUBackend : public Backend

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -234,7 +234,7 @@ void KernelManager::compileFromFile(const std::vector<std::string>& paths, const
 {
 	std::vector<std::string> sources;
 	for(const auto& path : paths)
-		sources.emplace_back((prepend!=""?"\n":"") + readKernel(path));
+		sources.emplace_back(prepend + (prepend!=""?"\n":"") + readKernel(path));
 	compileKernel(sources, program_name, kernel_names, force_override, flags);
 }
 
@@ -266,7 +266,7 @@ std::shared_ptr<TensorImpl> OpenCLBackend::cellActivity(const TensorImpl* x, con
 {
 	requireProperties(x, this, DType::Bool, IsContingous());
 	requireProperties(connections, this, DType::Int32, IsContingous());
-	requireProperties(permeances, this, IsDType{DType::Float, DType::Int32}, IsContingous());
+	requireProperties(permeances, this, IsDType{DType::Float, DType::Half}, IsContingous());
 	et_assert(connections->shape() == permeances->shape());
 	et_assert(connections->dimentions() >= 2);
 

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -790,7 +790,8 @@ std::shared_ptr<TensorImpl> OpenCLBackend::sum(const TensorImpl* x, size_t chunk
 		return DType::Int32;
 	}(x->dtype(), result_dtype);
 
-	std::string args = "-DInType=" + to_ctype_string(x->dtype()) + " -DOutType=" + to_ctype_string(result_dtype) + " -DIntermidType=" + to_ctype_string(intermid_type);
+	std::string args = "-DInType=" + to_ctype_string(x->dtype()) + " -DOutType=" + to_ctype_string(result_dtype) + " -DIntermidType=" + to_ctype_string(intermid_type)
+		+ (intermid_type==DType::Half? " -DIntermidIsHalf" : "");
 	std::string program_name = "sum" + hash_string(args);
 	kernel_manager_.compileFromFile("sum.cl", program_name, {"sum"}, false, args);
 

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -983,6 +983,8 @@ static DType solveBinaryOpDType(DType t1, DType t2)
 {
 	if(t1 == DType::Float || t2 == DType::Float)
 		return DType::Float;
+	else if(t1 == DType::Half || t2 == DType::Half)
+		return DType::Half;
 	return DType::Int32;
 }
 

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -111,7 +111,6 @@ void OpenCLBackend::init(cl::Context context, cl::Platform platform, cl::Device 
 std::shared_ptr<TensorImpl> OpenCLBackend::createTensor(const Shape& shape, DType dtype, const void* data)
 {
 	et_assert(dtype != DType::Unknown);
-	et_assert(dtype != DType::Half || have_fp16_ == true, "Creating half(fp16) tensor but device have no fp16 capablity.");
 	size_t buf_size = shape.volume()*dtypeToSize(dtype);
 	cl::Buffer buf = allocBuffer(buf_size);
 
@@ -131,6 +130,8 @@ std::shared_ptr<TensorImpl> OpenCLBackend::createTensor(const Shape& shape, DTyp
 
 std::shared_ptr<TensorImpl> OpenCLBackend::createTensor(const Shape& shape, DType dtype, cl::Buffer buf)
 {
+	if(dtype == DType::Half && have_fp16_ == false)
+		throw EtError("Creating half(fp16) tensor but device have no fp16 capablity.");
 	auto ptr = std::shared_ptr<OpenCLBuffer>(new OpenCLBuffer(shape, dtype, buf, shared_from_this()), [this](OpenCLBuffer* ptr){releaseTensor(ptr);});
 	return std::make_shared<TensorImpl>(ptr, shape, shapeToStride(shape));
 }

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -104,11 +104,14 @@ void OpenCLBackend::init(cl::Context context, cl::Platform platform, cl::Device 
 	std::string device_name = device_.getInfo<CL_DEVICE_NAME>();
 	et_assert(isExtentionSupported("cl_khr_local_int32_base_atomics"), "cl_khr_local_int32_base_atomics is not supported by " + device_name);
 	et_assert(isExtentionSupported("cl_khr_local_int32_extended_atomics"), "cl_khr_local_int32_extended_atomics is not supported by " + device_name);
+
+	have_fp16_ = isExtentionSupported("cl_khr_fp16");
 }
 
 std::shared_ptr<TensorImpl> OpenCLBackend::createTensor(const Shape& shape, DType dtype, const void* data)
 {
 	et_assert(dtype != DType::Unknown);
+	et_assert(dtype != DType::Half || have_fp16_ == true, "Creating half(fp16) tensor but device have no fp16 capablity.");
 	size_t buf_size = shape.volume()*dtypeToSize(dtype);
 	cl::Buffer buf = allocBuffer(buf_size);
 

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -349,7 +349,8 @@ std::shared_ptr<TensorImpl> OpenCLBackend::cast(const TensorImpl* x, DType toTyp
 {
 	et_assert(x->backend() == this);
 	et_assert(x->iscontiguous());
-	auto args = "-DInType="+to_ctype_string(x->dtype())+" -DOutType="+to_ctype_string(toType);
+	auto args = "-DInType="+to_ctype_string(x->dtype())+" -DOutType="+to_ctype_string(toType)
+		+ (x->dtype() == DType::Half || toType == DType::Half ? " -DHalfSupport" : "");
 	auto hash = hash_string(args);
 	auto program_name = "cast"+hash;
 	kernel_manager_.compileFromFile("cast.cl", program_name, {"cast"}, false, args);

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -164,6 +164,7 @@ std::string OpenCLBackend::deviceInfo() const
 	res += "Local memory size: " + std::to_string(localMemorySize()/1024) + " KB\n";
 	res += "Local memory type: " + local_type[localMemoryType()] + "\n";
 	res += "Prefered work group size: " + std::to_string(kernel_manager_.kernel("__etaler_dummy__").getWorkGroupInfo<CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE>(device_)) + "\n";
+	res += "Half percision: " + std::string(isExtentionSupported("cl_khr_fp16") ? "Yes" : "No");
 	return res;
 }
 

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -775,6 +775,8 @@ std::shared_ptr<TensorImpl> OpenCLBackend::sum(const TensorImpl* x, size_t chunk
 			DType dtype = x->dtype();
 			if(dtype == DType::Bool || dtype == DType::Int32)
 				return DType::Int32;
+			else if(dtype == DType::Half)
+				return DType::Half;
 			else
 				return DType::Float;
 		}();
@@ -783,6 +785,8 @@ std::shared_ptr<TensorImpl> OpenCLBackend::sum(const TensorImpl* x, size_t chunk
 	DType intermid_type = [](DType in, DType out) {
 		if(in == DType::Float)
 			return DType::Float;
+		if(out == DType::Half)
+			return DType::Half;
 		return DType::Int32;
 	}(x->dtype(), result_dtype);
 

--- a/Etaler/Backends/OpenCLBackend.hpp
+++ b/Etaler/Backends/OpenCLBackend.hpp
@@ -52,9 +52,9 @@ struct KernelManager
 	void compileKernel(const std::vector<std::string>& srcs, const std::string& program_name, const std::vector<std::string>& kernel_names
 		, bool force_override=false, const std::string& flags="");
 	void compileFromFile(const std::string& paths, const std::string& program_name, const std::vector<std::string>& kernel_names
-		, bool force_override=false, const std::string& flags="");
+		, bool force_override=false, const std::string& flags="", const std::string& prepend="");
 	void compileFromFile(const std::vector<std::string>& paths, const std::string& program_name, const std::vector<std::string>& kernel_names
-		, bool force_override=false, const std::string& flags="");
+		, bool force_override=false, const std::string& flags="", const std::string& prepend="");
 	inline bool exists(const std::string& program_name, const std::string& kernel_name)
 	{
 		auto it = apps_.find(program_name);

--- a/Etaler/Backends/OpenCLBackend.hpp
+++ b/Etaler/Backends/OpenCLBackend.hpp
@@ -187,6 +187,7 @@ protected:
 	cl_uint num_compute_units_;
 
 	std::vector<std::string> supported_extentions_;
+	bool have_fp16_ = false;
 };
 
 }

--- a/Etaler/Backends/OpenCLBackend.hpp
+++ b/Etaler/Backends/OpenCLBackend.hpp
@@ -138,7 +138,7 @@ struct ETALER_EXPORT OpenCLBackend : public Backend
 
 	inline cl::Context context() {return context_;}
 
-	inline bool isExtentionSupported(std::string ext)
+	inline bool isExtentionSupported(std::string ext) const
 	{
 		return (std::find(supported_extentions_.begin(), supported_extentions_.end(), ext)
 			!= supported_extentions_.end());

--- a/Etaler/CMakeLists.txt
+++ b/Etaler/CMakeLists.txt
@@ -15,6 +15,7 @@ generate_export_header(Etaler EXPORT_FILE_NAME Etaler_export.h)
 
 target_include_directories(Etaler PRIVATE 3rdparty/pcg-cpp/include)
 target_include_directories(Etaler PRIVATE 3rdparty/cereal/include)
+target_include_directories(Etaler PRIVATE 3rdparty/half_precision)
 target_include_directories(Etaler PRIVATE 3rdparty)
 
 if(${TBB_FOUND})

--- a/Etaler/Core/DType.hpp
+++ b/Etaler/Core/DType.hpp
@@ -4,6 +4,8 @@
 #include <limits>
 #include <string>
 
+#include "Half.hpp"
+
 namespace et
 {
 
@@ -13,6 +15,7 @@ enum class DType
 	Bool = 0,
 	Int32,
 	Float,
+	Half,
 };
 
 template <typename T>
@@ -24,11 +27,13 @@ constexpr inline DType typeToDType()
 		return DType::Int32;
 	else if constexpr(std::is_same<T, bool>::value || std::is_same<T, uint8_t>::value)
 		return DType::Bool;
+	else if constexpr(std::is_same<T, float16>::value)
+		return DType::Half;
 	else
 		return DType::Unknown;
 }
 
-inline size_t dtypeToSize(DType dtype)
+inline constexpr size_t dtypeToSize(DType dtype)
 {
 	if(dtype == DType::Bool)
 		return sizeof(bool);
@@ -36,6 +41,8 @@ inline size_t dtypeToSize(DType dtype)
 		return sizeof(int32_t);
 	else if(dtype == DType::Float)
 		return sizeof(float);
+	else if(dtype == DType::Half)
+		return sizeof(float16);
 	return std::numeric_limits<size_t>::max();
 }
 
@@ -47,6 +54,8 @@ inline std::string to_ctype_string(DType dtype)
 		return "int";
 	else if(dtype == DType::Float)
 		return "float";
+	else if(dtype == DType::Half)
+		return "half";
 	return "Unknown";
 }
 

--- a/Etaler/Core/DefaultBackend.hpp
+++ b/Etaler/Core/DefaultBackend.hpp
@@ -8,7 +8,7 @@ namespace et
 {
 
 extern ETALER_EXPORT Backend* g_default_backend;
-extern std::shared_ptr<Backend> g_default_backend_hold;
+extern ETALER_EXPORT std::shared_ptr<Backend> g_default_backend_hold;
 
 inline void setDefaultBackend(Backend* backend) {g_default_backend = backend;}
 inline void setDefaultBackend(std::shared_ptr<Backend> backend) {g_default_backend_hold = backend; g_default_backend = backend.get();}

--- a/Etaler/Core/Half.hpp
+++ b/Etaler/Core/Half.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+namespace et
+{
+
+//A dummp float16 structure
+struct half
+{
+	uint16_t dummy_;
+};
+
+using float16 = half;
+
+}

--- a/Etaler/Core/Half.hpp
+++ b/Etaler/Core/Half.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
 #include <cstdint>
+#include <Etaler/3rdparty/half_precision/half.hpp>
 
 namespace et
 {
 
-//A dummp float16 structure
-struct half
-{
-	uint16_t dummy_;
-};
+using half = half_precision::half;
 
 using float16 = half;
 

--- a/Etaler/Core/Tensor.cpp
+++ b/Etaler/Core/Tensor.cpp
@@ -114,6 +114,8 @@ static void printNDArray(std::ostream& os, const void* ptr, Shape shape, DType d
 		prettyPrintTensor(os, (int32_t*)ptr, shape, 0, shape.size(), 0, truncate);
 	else if(dtype == DType::Bool)
 		prettyPrintTensor(os, (bool*)ptr, shape, 0, shape.size(), 0, truncate);
+	else if(dtype == DType::Half)
+		prettyPrintTensor(os, (half*)ptr, shape, 0, shape.size(), 0, truncate);
 	else
 		throw EtError("Printing tensor of this type is not supported.");
 }
@@ -220,6 +222,8 @@ Tensor et::zeros(const Shape& shape, DType dtype, Backend* backend)
 		return constant<int32_t>(shape, 0, backend);
 	else if(dtype == DType::Float)
 		return constant<float>(shape, 0, backend);
+	else if(dtype == DType::Half)
+		return constant<half>(shape, half(0), backend);
 	else
 		throw EtError("Cannot creatr a tensor of zeros of type " + to_ctype_string(dtype));
 }
@@ -232,6 +236,8 @@ Tensor et::ones(const Shape& shape, DType dtype, Backend* backend)
 		return constant<int32_t>(shape, 1, backend);
 	else if(dtype == DType::Float)
 		return constant<float>(shape, 1, backend);
+	else if(dtype == DType::Half)
+		return constant<half>(shape, half(1), backend);
 	else
 		throw EtError("Cannot creatr a tensor of ones of type " + to_ctype_string(dtype));
 }

--- a/Etaler/Core/TypeHelpers.hpp
+++ b/Etaler/Core/TypeHelpers.hpp
@@ -15,9 +15,20 @@
 		return r;\
 }()
 
+
+
 namespace et
 {
 
 std::string ETALER_EXPORT demangle(const char* name);
+
+template<typename Test, template<typename...> class Ref>
+struct is_specialization : std::false_type {};
+
+template<template<typename...> class Ref, typename... Args>
+struct is_specialization<Ref<Args...>, Ref>: std::true_type {};
+
+template<template<typename...> class Ref, typename... Args>
+const bool is_specialization_v = is_specialization<Ref<Args...>, Ref>::value;
 
 }

--- a/Etaler/Core/TypeList.hpp
+++ b/Etaler/Core/TypeList.hpp
@@ -1,0 +1,30 @@
+#include <type_traits>
+
+namespace et
+{
+//Using STL coding style in this file
+struct null_t {};
+
+template <typename T, typename U>
+struct type_list_node
+{
+    using head = T;
+    using tail = U;
+};
+
+template <typename ... Ts> struct type_list;
+
+// Case: Normal recursion. Consume one type per call.
+template <typename T, typename ... REST>
+struct type_list<T, REST...> { 
+    using type = type_list_node<T, typename type_list<REST...>::type>;
+};
+
+// Case: Recursion abort, because the list of types ran empty
+template <>
+struct type_list<> { using type = null_t; };
+
+template <typename ... Ts>
+using type_list_t = typename type_list<Ts...>::type;
+
+}

--- a/examples/spbench.cpp
+++ b/examples/spbench.cpp
@@ -12,6 +12,7 @@ using namespace et;
 float benchmarkSpatialPooler(const Shape& out_shape, const std::vector<Tensor>& x, size_t num_epoch)
 {
 	SpatialPooler sp(x[0].shape(), out_shape);
+	sp.permanences_ = sp.permanences_.cast(DType::Half);
 
 	//To make the OpenCL backen ptr-compile the kernels
 	Tensor t = zeros(x[0].shape(), DType::Bool);

--- a/kernels/cast.cl
+++ b/kernels/cast.cl
@@ -6,6 +6,10 @@
 	#error OutType not defined
 #endif
 
+#ifdef HalfSupport
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#endif
+
 //InType: Input Type
 //OutType: OutputType
 //global_size: arbitrary

--- a/kernels/cellActivity.cl
+++ b/kernels/cellActivity.cl
@@ -6,6 +6,10 @@
 	#error "MAX_SYNAPSE_PER_CELL not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 #ifndef NO_UNUSED_SYNAPSE
 	#define NO_UNUSED_SYNAPSE false
 #endif
@@ -15,7 +19,7 @@
 //INPUT_SIZE: The size of input SDR, must be smaller then CL_DEVICE_LOCAL_MEMORY_SIZE
 //NO_UNUSED_SYNAPSE: If there are unised synapses. Useful for sparial pooler, accelerates ~30%
 kernel void cellActivity(global bool* restrict x, global int* restrict synapses
-	, global float* restrict permeances, global int* restrict y
+	, global PERM_TYPE* restrict permeances, global int* restrict y
 	, float connected_perm, int active_threshold, int output_size)
 {
 	//Load input state into local memory for faster access

--- a/kernels/cellActivity_compressed_local.cl
+++ b/kernels/cellActivity_compressed_local.cl
@@ -6,6 +6,10 @@
 	#error "MAX_SYNAPSE_PER_CELL not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 #ifndef NO_UNUSED_SYNAPSE
 	#define NO_UNUSED_SYNAPSE false
 #endif
@@ -20,7 +24,7 @@ int up_round(int v, int mul)
 //INPUT_SIZE: The size of input SDR, must be smaller then CL_DEVICE_LOCAL_MEMORY_SIZE*8-8
 //NO_UNUSED_SYNAPSE: If there are unised synapses. Useful for sparial pooler, accelerates ~30%
 kernel void cellActivity(global bool* restrict x, global int* restrict synapses
-	, global float* restrict permeances, global int* restrict y
+	, global PERM_TYPE* restrict permeances, global int* restrict y
 	, float connected_perm, int active_threshold, int output_size)
 {
 	//Load input state into local memory for faster access

--- a/kernels/cellActivity_global.cl
+++ b/kernels/cellActivity_global.cl
@@ -6,6 +6,10 @@
 	#error "MAX_SYNAPSE_PER_CELL not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 #ifndef NO_UNUSED_SYNAPSE
 	#define NO_UNUSED_SYNAPSE false
 #endif
@@ -15,7 +19,7 @@
 //INPUT_SIZE: The size of input SDR, must be smaller then CL_DEVICE_LOCAL_MEMORY_SIZE
 //NO_UNUSED_SYNAPSE: If there are unised synapses. Useful for sparial pooler, accelerates ~30%
 kernel void cellActivity(global bool* restrict x, global int* restrict synapses
-	, global float* restrict permeances, global int* restrict y
+	, global PERM_TYPE* restrict permeances, global int* restrict y
 	, float connected_perm, int active_threshold, int output_size)
 {
 	int global_size = get_global_size(0);

--- a/kernels/decaySynapses.cl
+++ b/kernels/decaySynapses.cl
@@ -6,8 +6,12 @@
 	#error "MAX_SYNAPSE_PER_CELL is not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
 
-kernel void decaySynapses(global int* restrict connections, global float* restrict permeances, float threshold)
+
+kernel void decaySynapses(global int* restrict connections, global PERM_TYPE* restrict permeances, float threshold)
 {
 	int global_size = get_global_size(0);
 	int global_id = get_global_id(0);

--- a/kernels/growSynapses.cl
+++ b/kernels/growSynapses.cl
@@ -10,6 +10,10 @@
 	#error "MAX_SYNAPSE_PER_CELL is not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 //NOTE: The old version of this kernel might perform better with more cells
 
 //global_size: Arbitrary
@@ -20,7 +24,7 @@
 //x: The input SDR **IN SPARSE FORMAT**
 //aux: temporary buffer for storage, must be size of NUM_INPUT_BITS*global_size[0]
 kernel void growSynapses(global int* restrict x, global bool* restrict y, global int* restrict connections
-	, global float* restrict permeances, float initial_perm, int num_input_on_bits, global bool* restrict aux)
+	, global PERM_TYPE* restrict permeances, float initial_perm, int num_input_on_bits, global bool* restrict aux)
 {
 	int global_size = get_global_size(0);
 	int global_id = get_global_id(0);

--- a/kernels/learnCorrilation.cl
+++ b/kernels/learnCorrilation.cl
@@ -10,6 +10,10 @@
 	#error "OUTPUT_SIZE not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 #ifndef NO_UNUSED_SYNAPSE
 	#define NO_UNUSED_SYNAPSE false
 #endif
@@ -19,7 +23,7 @@
 //INPUT_SIZE: The size of input SDR, must be smaller then CL_DEVICE_LOCAL_MEMORY_SIZE
 //NO_UNUSED_SYNAPSE: If there are unised synapses. Useful for sparial pooler, accelerates ~30%
 kernel void learnCorrilation(global bool* restrict x, global bool* restrict y
-	, global int* restrict synapses, global float* restrict permeances
+	, global int* restrict synapses, global PERM_TYPE* restrict permeances
 	, float permeance_inc, float permeance_dec)
 {
 	local char xl[INPUT_SIZE];

--- a/kernels/learnCorrilation_compressed_local.cl
+++ b/kernels/learnCorrilation_compressed_local.cl
@@ -10,6 +10,10 @@
 	#error "OUTPUT_SIZE not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 #ifndef NO_UNUSED_SYNAPSE
 	#define NO_UNUSED_SYNAPSE false
 #endif
@@ -19,7 +23,7 @@
 //INPUT_SIZE: The size of input SDR, must be smaller then CL_DEVICE_LOCAL_MEMORY_SIZE*8-8
 //NO_UNUSED_SYNAPSE: If there are unised synapses. Useful for sparial pooler, accelerates ~30%
 kernel void learnCorrilation(global bool* restrict x, global bool* restrict y
-	, global int* restrict synapses, global float* restrict permeances
+	, global int* restrict synapses, global PERM_TYPE* restrict permeances
 	, float permeance_inc, float permeance_dec)
 {
 	local char xl[INPUT_SIZE/8+1];

--- a/kernels/learnCorrilation_global.cl
+++ b/kernels/learnCorrilation_global.cl
@@ -10,6 +10,10 @@
 	#error "OUTPUT_SIZE not defined"
 #endif
 
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
 #ifndef NO_UNUSED_SYNAPSE
 	#define NO_UNUSED_SYNAPSE false
 #endif
@@ -19,7 +23,7 @@
 //INPUT_SIZE: The size of input SDR, must be smaller then CL_DEVICE_LOCAL_MEMORY_SIZE
 //NO_UNUSED_SYNAPSE: If there are unised synapses. Useful for sparial pooler, accelerates ~30%
 kernel void learnCorrilation(global bool* restrict x, global bool* restrict y
-	, global int* restrict synapses, global float* restrict permeances
+	, global int* restrict synapses, global PERM_TYPE* restrict permeances
 	, float permeance_inc, float permeance_dec)
 {
 	int global_size = get_global_size(0);

--- a/kernels/sort.cl
+++ b/kernels/sort.cl
@@ -3,16 +3,20 @@
 	#error "MAX_SYNAPSE_PER_CELL not defined"
 #endif
 
-void merge(global unsigned int* restrict a1, global float* restrict a2, int l, int m, int r
-	, global unsigned int* restrict aux_buffer1, global float* restrict aux_buffer2)
+#ifndef PERM_TYPE
+	#error "PERM_TYPE not defined"
+#endif
+
+void merge(global unsigned int* restrict a1, global PERM_TYPE* restrict a2, int l, int m, int r
+	, global unsigned int* restrict aux_buffer1, global PERM_TYPE* restrict aux_buffer2)
 {
 	int n1 = m - l + 1;
 	int n2 =  r - m;
 
 	global unsigned int* restrict L = aux_buffer1;
 	global unsigned int* restrict R = aux_buffer1+n1;
-	global float* restrict L2 = aux_buffer2;
-	global float* restrict R2 = aux_buffer2+n1;
+	global PERM_TYPE* restrict L2 = aux_buffer2;
+	global PERM_TYPE* restrict R2 = aux_buffer2+n1;
 
 	for (int i=0;i<n1;i++) {
 		L[i] = a1[l+i];
@@ -56,8 +60,8 @@ void merge(global unsigned int* restrict a1, global float* restrict a2, int l, i
 	}
 }
 
-void mergeSort(global unsigned int* restrict connections, global float* restrict permeances, int n
-	,global unsigned int* restrict aux_buffer1, global float* restrict aux_buffer2)
+void mergeSort(global unsigned int* restrict connections, global PERM_TYPE* restrict permeances, int n
+	,global unsigned int* restrict aux_buffer1, global PERM_TYPE* restrict aux_buffer2)
 {
 	for (int curr_size=1; curr_size<=n-1; curr_size = 2*curr_size) {
 	   for (int left_start=0; left_start<n-1; left_start += 2*curr_size) {

--- a/kernels/sum.cl
+++ b/kernels/sum.cl
@@ -10,6 +10,10 @@
         #error IntermidType not defined
 #endif
 
+#ifdef IntermidIsHalf
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#endif
+
 //InType: Input Data type
 //OutType: Output Data type
 //in_size: number of elements of the input

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -604,7 +604,36 @@ TEST_CASE("Type system")
 			CHECK(exp(ones({1}, DType::Bool)).dtype() == DType::Float);
 			CHECK(exp(ones({1}, DType::Int32)).dtype() == DType::Float);
 			CHECK(exp(ones({1}, DType::Float)).dtype() == DType::Float);
-			CHECK(exp(ones({1}, DType::Half)).dtype() == DType::Half);
+			//Disabled for now due to some GPU not supporting FP16
+			// CHECK(exp(ones({1}, DType::Half)).dtype() == DType::Half);
+		}
+
+		SECTION("negation") {
+			CHECK((-ones({1}, DType::Bool)).dtype() == DType::Int32);
+			CHECK((-ones({1}, DType::Int32)).dtype() == DType::Int32);
+			CHECK((-ones({1}, DType::Float)).dtype() == DType::Float);
+			// CHECK((-ones({1}, DType::Half)).dtype() == DType::Half);
+		}
+
+		SECTION("inverse") {
+			CHECK(inverse(ones({1}, DType::Bool)).dtype() == DType::Float);
+			CHECK(inverse(ones({1}, DType::Int32)).dtype() == DType::Float);
+			CHECK(inverse(ones({1}, DType::Float)).dtype() == DType::Float);
+			// CHECK(inverse(ones({1}, DType::Half)).dtype() == DType::Half);
+		}
+
+		SECTION("log") {
+			CHECK(log(ones({1}, DType::Bool)).dtype() == DType::Float);
+			CHECK(log(ones({1}, DType::Int32)).dtype() == DType::Float);
+			CHECK(log(ones({1}, DType::Float)).dtype() == DType::Float);
+			// CHECK(log(ones({1}, DType::Half)).dtype() == DType::Half);
+		}
+
+		SECTION("logical_not") {
+			CHECK(logical_not(ones({1}, DType::Bool)).dtype() == DType::Bool);
+			CHECK(logical_not(ones({1}, DType::Int32)).dtype() == DType::Bool);
+			CHECK(logical_not(ones({1}, DType::Float)).dtype() == DType::Bool);
+			// CHECK(logical_not(ones({1}, DType::Half)).dtype() == DType::Bool);
 		}
 	}
 }

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -600,40 +600,50 @@ TEST_CASE("Type system")
 	}
 
 	SECTION("type of Tensor operatoins") {
+		bool support_fp16 = [&](){
+			try {ones({1}, DType::Half);}
+			catch(const EtError&) {return false;}
+			return true;
+		}();
+
 		SECTION("exp") {
 			CHECK(exp(ones({1}, DType::Bool)).dtype() == DType::Float);
 			CHECK(exp(ones({1}, DType::Int32)).dtype() == DType::Float);
 			CHECK(exp(ones({1}, DType::Float)).dtype() == DType::Float);
-			//Disabled for now due to some GPU not supporting FP16
-			// CHECK(exp(ones({1}, DType::Half)).dtype() == DType::Half);
+			if(support_fp16)
+				CHECK(exp(ones({1}, DType::Half)).dtype() == DType::Half);
 		}
 
 		SECTION("negation") {
 			CHECK((-ones({1}, DType::Bool)).dtype() == DType::Int32);
 			CHECK((-ones({1}, DType::Int32)).dtype() == DType::Int32);
 			CHECK((-ones({1}, DType::Float)).dtype() == DType::Float);
-			// CHECK((-ones({1}, DType::Half)).dtype() == DType::Half);
+			if(support_fp16)
+				CHECK((-ones({1}, DType::Half)).dtype() == DType::Half);
 		}
 
 		SECTION("inverse") {
 			CHECK(inverse(ones({1}, DType::Bool)).dtype() == DType::Float);
 			CHECK(inverse(ones({1}, DType::Int32)).dtype() == DType::Float);
 			CHECK(inverse(ones({1}, DType::Float)).dtype() == DType::Float);
-			// CHECK(inverse(ones({1}, DType::Half)).dtype() == DType::Half);
+			if(support_fp16)
+				CHECK(inverse(ones({1}, DType::Half)).dtype() == DType::Half);
 		}
 
 		SECTION("log") {
 			CHECK(log(ones({1}, DType::Bool)).dtype() == DType::Float);
 			CHECK(log(ones({1}, DType::Int32)).dtype() == DType::Float);
 			CHECK(log(ones({1}, DType::Float)).dtype() == DType::Float);
-			// CHECK(log(ones({1}, DType::Half)).dtype() == DType::Half);
+			if(support_fp16)
+				CHECK(log(ones({1}, DType::Half)).dtype() == DType::Half);
 		}
 
 		SECTION("logical_not") {
 			CHECK(logical_not(ones({1}, DType::Bool)).dtype() == DType::Bool);
 			CHECK(logical_not(ones({1}, DType::Int32)).dtype() == DType::Bool);
 			CHECK(logical_not(ones({1}, DType::Float)).dtype() == DType::Bool);
-			// CHECK(logical_not(ones({1}, DType::Half)).dtype() == DType::Bool);
+			if(support_fp16)
+				CHECK(logical_not(ones({1}, DType::Half)).dtype() == DType::Bool);
 		}
 	}
 }

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -586,17 +586,17 @@ TEST_CASE("SDRClassifer")
 TEST_CASE("Type system")
 {
 	SECTION("Type sizes") {
-		REQUIRE(dtypeToSize(DType::Bool) == 1);
-		REQUIRE(dtypeToSize(DType::Int32) == 4);
-		REQUIRE(dtypeToSize(DType::Float) == 4);
-		REQUIRE(dtypeToSize(DType::Half) == 2);
+		STATIC_REQUIRE(dtypeToSize(DType::Bool) == 1);
+		STATIC_REQUIRE(dtypeToSize(DType::Int32) == 4);
+		STATIC_REQUIRE(dtypeToSize(DType::Float) == 4);
+		STATIC_REQUIRE(dtypeToSize(DType::Half) == 2);
 	}
 
 	SECTION("type to dtype") {
-		REQUIRE(typeToDType<int32_t>() == DType::Int32);
-		REQUIRE(typeToDType<float>() == DType::Float);
-		REQUIRE(typeToDType<bool>() == DType::Bool);
-		REQUIRE(typeToDType<half>() == DType::Half);
+		STATIC_REQUIRE(typeToDType<int32_t>() == DType::Int32);
+		STATIC_REQUIRE(typeToDType<float>() == DType::Float);
+		STATIC_REQUIRE(typeToDType<bool>() == DType::Bool);
+		STATIC_REQUIRE(typeToDType<half>() == DType::Half);
 	}
 
 	SECTION("type of Tensor operatoins") {

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -645,6 +645,14 @@ TEST_CASE("Type system")
 			if(support_fp16)
 				CHECK(logical_not(ones({1}, DType::Half)).dtype() == DType::Bool);
 		}
+
+		SECTION("sum") {
+			CHECK(ones({1}, DType::Bool).sum().dtype() == DType::Int32);
+			CHECK(ones({1}, DType::Int32).sum().dtype() == DType::Int32);
+			CHECK(ones({1}, DType::Float).sum().dtype() == DType::Float);
+			if(support_fp16)
+				CHECK(ones({1}, DType::Half).sum().dtype() == DType::Half);
+		}
 	}
 }
 

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -140,6 +140,17 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 		CHECK(q.isSame(r));
 	}
 
+	SECTION("Property Check") {
+		CHECK_NOTHROW(requireProperties(ones(Shape{1}, DType::Int32).pimpl(), DType::Int32));
+		CHECK_THROWS(requireProperties(ones(Shape{1}, DType::Float).pimpl(), DType::Int32));
+		CHECK_THROWS(requireProperties(ones(Shape{1}, DType::Float).pimpl(), IsDType{DType::Int32, DType::Bool}));
+
+		CHECK_NOTHROW(requireProperties(ones(Shape{1}, DType::Int32).pimpl(), defaultBackend()));
+
+		CHECK_NOTHROW(requireProperties(ones(Shape{1}, DType::Int32).pimpl(), IsContingous()));
+		CHECK_THROWS(requireProperties(ones(Shape{4,4}, DType::Int32).view({range(2), range(2)}).pimpl(), IsContingous()));
+	}
+
 	SECTION("Views") {
 		std::vector<int> data(16);
 		for(size_t i=0;i<data.size();i++)

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -17,25 +17,6 @@ TEST_CASE("default backend sanity")
 	REQUIRE(defaultBackend() != nullptr);
 }
 
-TEST_CASE("Type system")
-{
-	SECTION("Type sizes") {
-		REQUIRE(dtypeToSize(DType::Bool) == 1);
-		REQUIRE(dtypeToSize(DType::Int32) == 4);
-		REQUIRE(dtypeToSize(DType::Float) == 4);
-		REQUIRE(dtypeToSize(DType::Half) == 2);
-	}
-
-	SECTION("type to dtype") {
-		REQUIRE(typeToDType<int32_t>() == DType::Int32);
-		REQUIRE(typeToDType<float>() == DType::Float);
-		REQUIRE(typeToDType<bool>() == DType::Bool);
-		REQUIRE(typeToDType<half>() == DType::Half);
-	}
-
-	//TODO: Add type check for tensor operations
-}
-
 TEST_CASE("Testing Shape", "[Shape]")
 {
 	Shape s = {3,5};
@@ -600,6 +581,32 @@ TEST_CASE("SDRClassifer")
 	
 	for(size_t i=0;i<num_category;i++)
 		CHECK(classifer.compute(encoder::category(i, num_category, num_bits),0) == i);
+}
+
+TEST_CASE("Type system")
+{
+	SECTION("Type sizes") {
+		REQUIRE(dtypeToSize(DType::Bool) == 1);
+		REQUIRE(dtypeToSize(DType::Int32) == 4);
+		REQUIRE(dtypeToSize(DType::Float) == 4);
+		REQUIRE(dtypeToSize(DType::Half) == 2);
+	}
+
+	SECTION("type to dtype") {
+		REQUIRE(typeToDType<int32_t>() == DType::Int32);
+		REQUIRE(typeToDType<float>() == DType::Float);
+		REQUIRE(typeToDType<bool>() == DType::Bool);
+		REQUIRE(typeToDType<half>() == DType::Half);
+	}
+
+	SECTION("type of Tensor operatoins") {
+		SECTION("exp") {
+			CHECK(exp(ones({1}, DType::Bool)).dtype() == DType::Float);
+			CHECK(exp(ones({1}, DType::Int32)).dtype() == DType::Float);
+			CHECK(exp(ones({1}, DType::Float)).dtype() == DType::Float);
+			CHECK(exp(ones({1}, DType::Half)).dtype() == DType::Half);
+		}
+	}
 }
 
 // TEST_CASE("Serealize")

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -17,6 +17,25 @@ TEST_CASE("default backend sanity")
 	REQUIRE(defaultBackend() != nullptr);
 }
 
+TEST_CASE("Type system")
+{
+	SECTION("Type sizes") {
+		REQUIRE(dtypeToSize(DType::Bool) == 1);
+		REQUIRE(dtypeToSize(DType::Int32) == 4);
+		REQUIRE(dtypeToSize(DType::Float) == 4);
+		REQUIRE(dtypeToSize(DType::Half) == 2);
+	}
+
+	SECTION("type to dtype") {
+		REQUIRE(typeToDType<int32_t>() == DType::Int32);
+		REQUIRE(typeToDType<float>() == DType::Float);
+		REQUIRE(typeToDType<bool>() == DType::Bool);
+		REQUIRE(typeToDType<half>() == DType::Half);
+	}
+
+	//TODO: Add type check for tensor operations
+}
+
 TEST_CASE("Testing Shape", "[Shape]")
 {
 	Shape s = {3,5};

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -653,6 +653,64 @@ TEST_CASE("Type system")
 			if(support_fp16)
 				CHECK(ones({1}, DType::Half).sum().dtype() == DType::Half);
 		}
+
+		auto solve_binary_op_type = [](DType self, DType other)->DType {
+			// Implement a C++ like type promotion rule
+			if(other == DType::Float || self == DType::Float)
+					return DType::Float;
+				else if(other == DType::Half || self == DType::Half)
+					return DType::Half;
+				return DType::Int32; //Even bool is promoted to int in operation
+		};
+
+		std::vector<DType> types = {DType::Int32, DType::Bool, DType::Float, DType::Half};
+		SECTION("add") {
+			for(auto t1 : types) {
+				for(auto t2 : types) {
+					if((t1 == DType::Half || t2 == DType::Half) && support_fp16 == false)
+						continue;
+					Tensor t = ones({1}, t1);
+					Tensor q = ones({1}, t2);
+					CHECK((t+q).dtype() == solve_binary_op_type(t1, t2));
+				}
+			}
+		}
+
+		SECTION("subtract") {
+			for(auto t1 : types) {
+				for(auto t2 : types) {
+					if((t1 == DType::Half || t2 == DType::Half) && support_fp16 == false)
+						continue;
+					Tensor t = ones({1}, t1);
+					Tensor q = ones({1}, t2);
+					CHECK((t-q).dtype() == solve_binary_op_type(t1, t2));
+				}
+			}
+		}
+
+		SECTION("mul") {
+			for(auto t1 : types) {
+				for(auto t2 : types) {
+					if((t1 == DType::Half || t2 == DType::Half) && support_fp16 == false)
+						continue;
+					Tensor t = ones({1}, t1);
+					Tensor q = ones({1}, t2);
+					CHECK((t*q).dtype() == solve_binary_op_type(t1, t2));
+				}
+			}
+		}
+
+		SECTION("div") {
+			for(auto t1 : types) {
+				for(auto t2 : types) {
+					if((t1 == DType::Half || t2 == DType::Half) && support_fp16 == false)
+						continue;
+					Tensor t = ones({1}, t1);
+					Tensor q = ones({1}, t2);
+					CHECK((t/q).dtype() == solve_binary_op_type(t1, t2));
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
WIP:

This PR aims to:
- [x] Add support to create FP16 tensor
- [x] Add FP16 tensor operators
- [x] Optimize HTM algorithm against FP16
- [x] Clean up how tensor's properties are checked in the backend
  * Reduce LoC, more readable

To both CPU and OpenCL backend.

And for OpenCL exclusively:
- [x] Check the given OpenCL device can process FP16

Tests for the type system
- [x] Check types have the correct size
- [x] Check resulting type of unitary operations
- [x] Check resulting type of binary operations
  * Besides comparison ops, I;m lazy
- [x] Check resulting type of general tensor operations
- [x] Somehow disable the fp16 tests when GPU doesn't support FP16
- [x] A way to convert SP/TM from float to float16
   - Just cast the permeance!

Serialize:
- [x] Save/load fp16 tensors


Ref #12 