### PR TITLE
Fix building Etaler on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") #GCC flags
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-unused-but-set-parameter")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto")
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") #clang flags
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" or ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang") #clang flags
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unused-function")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto")
 else()

--- a/Etaler/CMakeLists.txt
+++ b/Etaler/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(Etaler PRIVATE 3rdparty)
 
 if(${TBB_FOUND})
 	target_link_libraries(Etaler ${TBB_IMPORTED_TARGETS})
+	target_include_directories(Etaler PRIVATE ${TBB_INCLUDE_DIRS})
 else()
 	target_link_libraries(Etaler tbb)
 endif()


### PR DESCRIPTION
related to #62 

This PR includes patches to handle issues introduces by changes after 0.1 release causing OS X build failed. Now Etaler should be build-able on OS X by:

* Install tbb, cmake, gcc, cereal, catch2 from homebrew

Then by using the commands
```
git clone https://github.com/etaler/Etaler --recursive
cd Etaler
mkdir build
cd build
cmake -DCMAKE_CXX_COMPILER=g++9
make -j4
```

Compiling using clang causes linker errors. I'm still investigating that.