### PR TITLE
Relax indexing requiements

### DIFF
--- a/Etaler/Algorithms/SpatialPooler.hpp
+++ b/Etaler/Algorithms/SpatialPooler.hpp
@@ -40,7 +40,7 @@ struct ETALER_EXPORT SpatialPooler
 	size_t activeThreshold() const { return active_threshold_; }
 
 	void setGlobalDensity(float d) { global_density_ = d; }
-	size_t globalDensity() const { return global_density_; }
+	float globalDensity() const { return global_density_; }
 
 	void setBoostingFactor(float f) { boost_factor_ = f; }
 	float boostFactor() const { return boost_factor_; }

--- a/Etaler/Backends/CPUBackend.cpp
+++ b/Etaler/Backends/CPUBackend.cpp
@@ -88,6 +88,11 @@ inline void dispatch2d(DType t1, DType t2, Func f)
 	});
 }
 
+CPUBuffer::~CPUBuffer()
+{
+	std::visit([](auto& ptr){delete [] ptr;}, storage_);
+}
+
 namespace et::detail
 {
 template <typename PermType>

--- a/Etaler/Backends/CPUBackend.hpp
+++ b/Etaler/Backends/CPUBackend.hpp
@@ -39,7 +39,7 @@ struct ETALER_EXPORT CPUBuffer : public BufferImpl
 			memcpy(ptr, src_ptr, shape.volume()*dtypeToSize(dtype));
 	}
 
-	virtual ~CPUBuffer() {std::visit([](auto& ptr){delete [] ptr;}, storage_);}
+	virtual ~CPUBuffer();
 
 	virtual void* data() const override;
 

--- a/Etaler/Core/Backend.hpp
+++ b/Etaler/Core/Backend.hpp
@@ -73,3 +73,12 @@ struct ETALER_EXPORT Backend : public std::enable_shared_from_this<Backend>
 
 }
 
+namespace cling
+{
+
+inline std::string printValue(const et::Backend* backend)
+{
+	return "<Etaler backend on " + backend->name() + ">";
+}
+
+}

--- a/Etaler/Core/Error.cpp
+++ b/Etaler/Core/Error.cpp
@@ -19,11 +19,14 @@ ETALER_EXPORT bool et::getEnableTraceOnException()
 	return g_enable_trace_on_exception;
 }
 
-std::string et::genStackTrace()
+std::string et::genStackTrace(size_t skip)
 {
 #ifndef BACKWARD_SYSTEM_UNKNOWN
 	std::stringstream ss;
 	StackTrace st;
+	// Skip the at least function calls we don't want
+	// 1. unwind 2. load_here, 3. genStackTrace
+	st.skip_n_firsts(3+skip);
 	st.load_here(32);
 	Printer p;
 	p.color_mode = ColorMode::never;
@@ -44,5 +47,5 @@ ETALER_EXPORT EtError::EtError(const std::string &msg)
 	: msg_(msg)
 {
 	if(getEnableTraceOnException())
-		msg_ += "\n"+genStackTrace();
+		msg_ += "\n"+genStackTrace(1); // Skip the EtError ctor
 }

--- a/Etaler/Core/Error.cpp
+++ b/Etaler/Core/Error.cpp
@@ -11,7 +11,7 @@ static bool g_enable_trace_on_exception = true;
 
 ETALER_EXPORT void et::enableTraceOnException(bool enable)
 {
-	g_enable_trace_on_exception = true;
+	g_enable_trace_on_exception = enable;
 }
 
 ETALER_EXPORT bool et::getEnableTraceOnException()

--- a/Etaler/Core/Error.cpp
+++ b/Etaler/Core/Error.cpp
@@ -44,5 +44,5 @@ ETALER_EXPORT EtError::EtError(const std::string &msg)
 	: msg_(msg)
 {
 	if(getEnableTraceOnException())
-		msg_ += genStackTrace();
+		msg_ += "\n"+genStackTrace();
 }

--- a/Etaler/Core/Error.hpp
+++ b/Etaler/Core/Error.hpp
@@ -12,7 +12,7 @@
 namespace et
 {
 
-std::string genStackTrace();
+std::string genStackTrace(size_t skip = 0);
 
 class EtError : public std::exception
 {

--- a/Etaler/Core/Tensor.cpp
+++ b/Etaler/Core/Tensor.cpp
@@ -226,7 +226,7 @@ Tensor Tensor::view(const IndexList& rgs) const
 		if(is_index_valid(start, dim_size) == false)
 			throw EtError("Index " + std::to_string(start) + " is out of range for dimension " + std::to_string(i) + " with size " + std::to_string(dim_size));
 		if((real_stop - real_start) * step < 0)
-			throw EtError("Step is going in the wrong direction.");
+			throw EtError("Step is going in the wrong direction in dimension " + std::to_string(i));
 
 		viewed_strides[i] *= step;
 

--- a/Etaler/Core/Tensor.hpp
+++ b/Etaler/Core/Tensor.hpp
@@ -172,9 +172,9 @@ struct ETALER_EXPORT Tensor
 
 	Tensor swapaxis(size_t axis1, size_t axis2) const
 	{
-		if(axis1 < dimentions())
+		if(axis1 >= dimentions())
 			throw EtError("Axis " + std::to_string(axis1) + " is out of range.");
-		if(axis2 < dimentions())
+		if(axis2 >= dimentions())
 			throw EtError("Axis " + std::to_string(axis2) + " is out of range.");
 		Shape stride = pimpl_->stride();
 		Shape s = shape();

--- a/Etaler/Core/TensorImpl.hpp
+++ b/Etaler/Core/TensorImpl.hpp
@@ -91,13 +91,14 @@ bool checkProperty(const TensorImpl* x, const T& value)
 }
 
 template <typename T>
-void requireProperty(const TensorImpl* x, const T value, const std::string& line, const std::string& v_name)
+void requireProperty(const TensorImpl* x, const T& value, const std::string_view line, const std::string_view v_name)
 {
 	if(checkProperty(x, value) == true)
 		return;
 	
-	//Otherwise assertion failed
-	const std::string msg = line + " Tensor property requirment not match. Expecting " + v_name;
+	// Otherwise assertion failed
+	// Workarround string_view limitations
+	const std::string msg = (std::string(line) + " Tensor property requirment not match. Expecting ").append(v_name);
 	if constexpr(std::is_base_of_v<Backend, std::remove_pointer_t<std::decay_t<T>>>)
 		throw EtError(msg + ".backend() == " + value->name());
 	else if constexpr(std::is_same_v<T, DType>)
@@ -115,13 +116,13 @@ void requireProperty(const TensorImpl* x, const T value, const std::string& line
 }
 
 template <typename ... Args>
-bool checkProperties(const TensorImpl* x, Args... args)
+bool checkProperties(const TensorImpl* x, const Args& ... args)
 {
 	return (checkProperty(x, args) && ...);
 }
 
 template <typename ... Args>
-void requirePropertiesInternal(const TensorImpl* x, const std::string& line, const std::string& v_name, Args... args)
+void requirePropertiesInternal(const TensorImpl* x, const std::string_view line, const std::string_view v_name, const Args& ... args)
 {
 	(requireProperty(x, args, line, v_name), ...);
 }

--- a/Etaler/Etaler.hpp
+++ b/Etaler/Etaler.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 //Includes common headers
-#include "Core/Shape.hpp"
-#include "Core/DType.hpp"
-#include "Core/Backend.hpp"
-#include "Core/Tensor.hpp"
-#include "Core/DefaultBackend.hpp"
+#include <Etaler/Core/Shape.hpp>
+#include <Etaler/Core/DType.hpp>
+#include <Etaler/Core/Backend.hpp>
+#include <Etaler/Core/Tensor.hpp>
+#include <Etaler/Core/DefaultBackend.hpp>

--- a/docs/source/UsingWithClingROOT.md
+++ b/docs/source/UsingWithClingROOT.md
@@ -74,6 +74,29 @@ root [0] gSystem->Load("/usr/local/lib/libEtaler.so");
 root [1] #include <Etaler/Etaler.hpp>
 ```
 
+Or use a macro to load Etaler conveniently
+```c++
+// /usr/share/root/macros/load_etaler.C
+#include <Etaler/Etaler.hpp>
+#include <Etaler/Algorithms/SpatialPooler.hpp>
+#include <Etaler/Algorithms/TemporalMemory.hpp>
+#include <Etaler/Encoders/Scalar.hpp>
+#include <Etaler/Encoders/GridCell1d.hpp>
+#include <Etaler/Encoders/GridCell2d.hpp> // Add or remove headers as you want
+#pragma cling load("/usr/local/lib/libEtaler.so") // Repalce this with your path to Etaler
+using namespace et;
+
+void load_etaler(){}
+```
+
+Then call the macro in ROOT to load all of Etaler.
+
+```cpp
+> root
+root [0] .x load_etaler.C
+root [1] // Etaler is fully loaded
+```
+
 ## Using Etaler under an interactive C++ shell
 
 After loading the library. You can use the library as you would normally. (And ROOT imports the `std` namespace by default.)

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -219,7 +219,9 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 			CHECK_THROWS(t.view({0,0,0,0,0}));
 			CHECK_THROWS(t.view({300}));
 			CHECK_THROWS(t.view({0, 300}));
-			CHECK_THROWS(t.view({range(100)}));
+
+			// NumPy and PyTorch allows np.ones(4, 4)[:100]
+			CHECK_NOTHROW(t.view({range(100)}));
 
 			Tensor q = t.view({2,2});
 			CHECK(q.size() == 1);

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -186,6 +186,9 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 		CHECK_NOTHROW(requireProperties(ones(Shape{1}, DType::Int32).pimpl(), IsPlain()));
 		CHECK_NOTHROW(requireProperties(ones(Shape{1}, DType::Int32).view({0}).pimpl(), IsPlain()));
 		CHECK_THROWS(requireProperties(ones(Shape{4,4}, DType::Int32).view({range(2), range(2)}).pimpl(), IsPlain()));
+
+		CHECK_NOTHROW(requireProperties(ones({Shape{4, 4}}).pimpl(), Shape{4, 4}));
+		CHECK_THROWS(requireProperties(ones({Shape{4, 4}}).pimpl(), Shape{4}));
 	}
 
 	SECTION("Views") {

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -361,24 +361,39 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 	}
 
 	SECTION("iterator") {
+		// Reference: http://www.cplusplus.com/reference/iterator/RandomAccessIterator/
 		Tensor t = ones({3, 4});
 		Tensor q = zeros({3, 4});
+		REQUIRE(t.shape() == Shape{3, 4});
 		STATIC_REQUIRE(std::is_same_v<Tensor::iterator::value_type, Tensor>);
 
-		// Tensor::iterator should be random,
-		// Reference: http://www.cplusplus.com/reference/iterator/RandomAccessIterator/
+		// Tensor::iterator should be a ramdom access iterator
 		STATIC_REQUIRE(std::is_same_v<std::iterator_traits<Tensor::iterator>::iterator_category, std::random_access_iterator_tag>);
+
+		//Is default-constructible, copy-constructible, copy-assignable and destructible
 		STATIC_REQUIRE(std::is_default_constructible_v<Tensor::iterator>);
 		STATIC_REQUIRE(std::is_copy_constructible_v<Tensor::iterator>);
 		STATIC_REQUIRE(std::is_copy_assignable_v<Tensor::iterator>);
 		STATIC_REQUIRE(std::is_destructible_v<Tensor::iterator>);
-
+		
+		//Can be compared for equivalence using the equality/inequality operators
 		CHECK(t.begin() != t.end());
 		CHECK(t.begin() == t.begin());
+
+		//Can be dereferenced as an rvalue
 		CHECK((*t.begin()).shape() == Shape{4});
 		CHECK(t.begin()->shape() == Shape{4});
+
+		//Can be dereferenced as an lvalue
+		CHECK((*t.begin() = zeros({4})).isSame(zeros({4})));
+		CHECK((*t.begin() = ones({4})).isSame(ones({4}))); // Try a second time
+
+		//Supports the arithmetic operators + and - between an iterator and an integer value, or subtracting an iterator from another.
 		CHECK(t.end() - t.begin() == t.shape()[0]);
-		CHECK(t.begin()[2].isSame(*t.back()) == true);
+		CHECK(t.begin() + t.shape()[0] == t.end());
+		CHECK(t.end() - t.shape()[0] == t.begin());
+
+		//Can be incremented
 		auto it1 = t.begin(), it2 = t.begin();
 		it1++;
 		++it2;
@@ -387,9 +402,27 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 		it2--;
 		CHECK(it1 == it2);
 
+		//Can be compared with inequality relational operators
+		CHECK(t.begin() < t.end());
+		CHECK(t.end() > t.begin());
+		CHECK(t.begin() <= t.begin());
+		CHECK(t.begin() >= t.begin());
+
+		//Supports compound assignment operations 
+		it1 = t.begin();
+		it1 += 3;
+		CHECK(it1 == t.end());
+		it2 = t.end();
+		it2 -= 3;
+		CHECK(it2 == t.begin());
+
+		//Supports the offset dereference operator
+		CHECK(t.begin()[2].isSame(*t.back()) == true);
+
 		swap(*t.begin(), *q.begin());
 		CHECK(t[{0}].isSame(zeros({4})));
 
+		// Other misc I came up
 		int num_iteration = 0;
 		for(auto s : t) {
 			CHECK(s.shape() == Shape({4}));

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -854,6 +854,15 @@ TEST_CASE("brodcast")
 		b = ones({7});
 		CHECK_THROWS(a+b);
 	}
+
+	SECTION("Manual brodcast") {
+		a = ones({2, 4});
+		b = ones({1, 1, 4});
+		auto [x, y] = a.brodcast(b);
+		CHECK(x.shape() == Shape({1, 2, 4}));
+		CHECK(y.shape() == Shape({1, 2, 4}));
+		CHECK(x.iscontiguous() == false);
+	}
 }
 
 TEST_CASE("SDRClassifer")


### PR DESCRIPTION
* Bug fixes
* Allow relaxed indexing
   * `ones({8}).view({range(6, 9000)})`
   * Crash before this PR
   * Now returns `Tensor({1, 1})`
   * Match NumPy behavior
* cppyy binding works again
* Backend is now printable via cling