### PR TITLE
typo: convert all `dimentions` to `dimensions`

### DIFF
--- a/Etaler/Backends/CPUBackend.cpp
+++ b/Etaler/Backends/CPUBackend.cpp
@@ -103,7 +103,7 @@ static std::shared_ptr<TensorImpl> cellActivity(const TensorImpl* x, const Tenso
 	requireProperties(x, backend, DType::Bool, IsPlain());
 	requireProperties(connections, backend, DType::Int32, IsPlain(), permeances->shape());
 	requireProperties(permeances, backend, typeToDType<PermType>(), IsPlain());
-	et_check(connections->dimentions() >= 2);
+	et_check(connections->dimensions() >= 2);
 
 	Shape s = connections->shape();
 	s.pop_back();

--- a/Etaler/Backends/OpenCLBackend.cpp
+++ b/Etaler/Backends/OpenCLBackend.cpp
@@ -41,7 +41,7 @@ typedef struct __attribute__ ((packed)) _OpenCLView
 
 static void makeOpenCLView(const TensorImpl* x, OpenCLView* v)
 {
-	int dims = int(x->dimentions());
+	int dims = int(x->dimensions());
 	et_assert(dims <= OPENCL_TENSOR_MAX_DIMS, "Too much dimensions for OpenCL backend.");
 	auto stride = x->stride();
 	auto shape_stride = shapeToStride(x->shape());
@@ -296,7 +296,7 @@ std::shared_ptr<TensorImpl> OpenCLBackend::cellActivity(const TensorImpl* x, con
 	requireProperties(x, this, DType::Bool, IsPlain());
 	requireProperties(connections, this, DType::Int32, IsPlain(), permeances->shape());
 	requireProperties(permeances, this, IsDType{DType::Float, DType::Half}, IsPlain());
-	et_check(connections->dimentions() >= 2);
+	et_check(connections->dimensions() >= 2);
 
 	Shape s = connections->shape();
 	s.pop_back();
@@ -694,7 +694,7 @@ int location_func$ID(int index)
 	const auto shape_stride = shapeToStride(x->shape());
 	replaceAll(func, "$ID", std::to_string(id));
 	replaceAll(func, "$SHAPE_STRIDE", to_string(shape_stride));
-	replaceAll(func, "$DIMS", std::to_string(x->dimentions()));
+	replaceAll(func, "$DIMS", std::to_string(x->dimensions()));
 	replaceAll(func, "$STRIDE", to_string(x->stride()));
 	replaceAll(func, "$OFFSET", std::to_string(x->offset()));
 	return func;

--- a/Etaler/Core/Tensor.hpp
+++ b/Etaler/Core/Tensor.hpp
@@ -106,7 +106,7 @@ struct ETALER_EXPORT Tensor
 	DType dtype() const {return pimpl_->dtype();}
 	Shape shape() const {if(pimpl_) return pimpl_->shape(); else return Shape();}
 	size_t size() const {return pimpl_->size();}
-	size_t dimentions() const {return pimpl_->dimentions();}
+	size_t dimensions() const {return pimpl_->dimensions();}
 	void resize(Shape s) {pimpl()->resize(s);}
 	bool iscontiguous() const {return pimpl()->iscontiguous();}
 	bool isplain() const {return pimpl()->isplain();}
@@ -160,7 +160,7 @@ struct ETALER_EXPORT Tensor
 		if(std::find_if(shape.begin(), shape.end(), [](auto v){ return v < -1;}) != shape.end())
                         throw EtError("Sizes of each dimension should be gerater than one or is -1 (unknown). Got " + to_string(shape));
 		size_t num_unknown = std::count_if(shape.begin(), shape.end(), [](auto v){return v == -1;}); // -1 indicates unknown size
-		et_check(num_unknown <= 1, "Can only have 0 or 1 unknown dimentions. Got " + std::to_string(num_unknown));
+		et_check(num_unknown <= 1, "Can only have 0 or 1 unknown dimensions. Got " + std::to_string(num_unknown));
 		if(num_unknown == 1) {
 			intmax_t known_volume = 1;
 			size_t unknown_index = -1;
@@ -190,9 +190,9 @@ struct ETALER_EXPORT Tensor
 
 	Tensor swapaxis(size_t axis1, size_t axis2) const
 	{
-		if(axis1 >= dimentions())
+		if(axis1 >= dimensions())
 			throw EtError("Axis " + std::to_string(axis1) + " is out of range.");
-		if(axis2 >= dimentions())
+		if(axis2 >= dimensions())
 			throw EtError("Axis " + std::to_string(axis2) + " is out of range.");
 		Shape stride = pimpl_->stride();
 		Shape s = shape();

--- a/Etaler/Core/TensorImpl.hpp
+++ b/Etaler/Core/TensorImpl.hpp
@@ -39,7 +39,7 @@ struct ETALER_EXPORT TensorImpl : public std::enable_shared_from_this<TensorImpl
 	Shape shape() const {return shape_;}
 	Shape stride() const {return stride_;}
 	std::shared_ptr<BufferImpl> buffer() const {return buffer_;}
-	size_t dimentions() const {return shape_.size();}
+	size_t dimensions() const {return shape_.size();}
 	size_t size() const {return shape_.volume();}
 	size_t offset() const {return offset_;}
 	void resize(Shape s) {if(isplain() && s.volume() == shape_.volume()){ shape_ = s; stride_ = shapeToStride(s);} else throw EtError("Cannot resize");}

--- a/Etaler/Interop/Arrayfire.hpp
+++ b/Etaler/Interop/Arrayfire.hpp
@@ -58,13 +58,13 @@ Tensor from_afarray(const af::array& arr, bool transpose=true)
 
 af::array to_afarray(const Tensor& t, bool transpose=true)
 {
-	et_assert(t.dimentions() <= 4);
+	et_assert(t.dimensions() <= 4);
 	af::dim4 dims;
 	//Initalize the dims (not Initalized by default)
 	for(int i=0;i<4;i++)
 		dims[i] = 1;
-	for(size_t i=0;i<t.dimentions();i++)
-		dims[t.dimentions()-i] = t.shape()[i];
+	for(size_t i=0;i<t.dimensions();i++)
+		dims[t.dimensions()-i] = t.shape()[i];
 
 	af::dtype dtype = [](DType dtype) {
 		if(dtype == DType::Float)

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -126,9 +126,9 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 
 		CHECK(t.size() == 1*2*5*6*7);
 		CHECK(t.dtype() == DType::Float);
-		CHECK(t.dimentions() == 5);
+		CHECK(t.dimensions() == 5);
 		CHECK(t.backend() == defaultBackend());
-		CHECK(t.dimentions() == t.shape().size());
+		CHECK(t.dimensions() == t.shape().size());
 
 		//Should not be able to convert from shape {1,2,5,3,7} to {60}
 		CHECK_THROWS_AS(t.resize({60}), EtError);
@@ -239,12 +239,12 @@ TEST_CASE("Testing Tensor", "[Tensor]")
 
 			Tensor q = t.view({2,2});
 			CHECK(q.size() == 1);
-			CHECK(q.dimentions() == 1);
+			CHECK(q.dimensions() == 1);
 			CHECK(realize(q).toHost<int32_t>()[0] == 10);
 
 			Tensor r = t.view({range(2), range(2)});
 			CHECK(r.size() == 4);
-			CHECK(r.dimentions() == 2);
+			CHECK(r.dimensions() == 2);
 			CHECK(r.shape() == Shape({2,2}));
 			int a[] = {0,1,4,5};
 			Tensor pred = Tensor({2,2}, a);
@@ -677,14 +677,14 @@ TEST_CASE("Backend functions", "[Backend]")
 
 		Tensor s0 = sum(t, 0);
 		CHECK(s0.size() == 4);
-		CHECK(s0.dimentions() == 1);
+		CHECK(s0.dimensions() == 1);
 		CHECK(s0.dtype() == DType::Int32);
 		int32_t pred0[] = {24, 28, 32, 36};
 		CHECK(s0.isSame(Tensor({4}, pred0)));
 
 		Tensor s1 = sum(t, 1);
 		CHECK(s1.size() == 4);
-		CHECK(s1.dimentions() == 1);
+		CHECK(s1.dimensions() == 1);
 		CHECK(s1.dtype() == DType::Int32);
 		int32_t pred1[] = {6, 22, 38, 54};
 		CHECK(s1.isSame(Tensor({4}, pred1)));


### PR DESCRIPTION
Fix for #137. Update all instances of `dimentions` to `dimensions`